### PR TITLE
Don't die when ffmpeg can't build screenshots in metadata:scan

### DIFF
--- a/lib/stash_metadata/tasks/scan.rb
+++ b/lib/stash_metadata/tasks/scan.rb
@@ -32,7 +32,13 @@ module StashMetadata
           checksum = Digest::MD5.file(path).hexdigest
           StashMetadata.logger.debug("Checksum calculated: #{checksum}")
 
-          make_screenshots(path: path, checksum: checksum) if klass == Scene
+          begin
+            make_screenshots(path: path, checksum: checksum) if klass == Scene
+          rescue
+            StashMetadata.logger.error("Error encoutered generating screenshots for #{path}. Skipping.")
+            next
+          end
+
 
           item = klass.find_by(checksum: checksum)
           if item


### PR DESCRIPTION
I had partial files that were in the process of being encoded and caused ffmpeg to bail. This allows for metadata:scan to skip over them with a warning.