### PR TITLE
Improvements to generate_marker_previews task

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The following rake tasks are included.
   * This will generate sprites and VTT files to provide video scrubbing previews.
 * `$ rails metadata:generate_previews`
   * This will generate webm preview files
+* `$ rails metadata:generate_marker_previews`
+  * This will generate webm preview files for scene markers
 
 # Questions
 

--- a/lib/stash_metadata/tasks/generate_marker_previews.rb
+++ b/lib/stash_metadata/tasks/generate_marker_previews.rb
@@ -19,11 +19,13 @@ module StashMetadata
             marker_path = File.join(scene_path, "#{marker.seconds.to_i.to_s}.mp4")
             tmp_marker_path = File.join(tmp_dir, "#{marker.seconds.to_i.to_s}.mp4")
             if !File.exist?(marker_path)
-              cmd = "ffmpeg -v quiet -ss #{marker.seconds.to_i} -t 20 -i \"#{scene.path}\" -c:v libx264 -profile:v high -level 4.2 -preset veryslow -crf 24 -movflags +faststart -threads 4 -vf scale=#{output_width}:-2 -sws_flags lanczos -c:a aac -b:a 64k '#{tmp_marker_path}'"
+              cmd = "ffmpeg -v quiet -ss #{marker.seconds.to_i} -t 20 -i \"#{scene.path}\" -c:v libx264 -profile:v high -level 4.2 -preset veryslow -crf 24 -movflags +faststart -threads 4 -vf scale=#{output_width}:-2 -sws_flags lanczos -c:a aac -b:a 64k -strict -2 '#{tmp_marker_path}'"
               StashMetadata.logger.info("Create marker for #{marker_path}")
-              system(cmd)
-              FileUtils.cp(tmp_marker_path, marker_path)
-              File.delete(tmp_marker_path)
+              unless system(cmd)
+                StashMetadata.logger.error("Error running ffmpeg #{$?}")
+              end
+
+              FileUtils.mv(tmp_marker_path, marker_path)
             end
 
             marker_path = File.join(scene_path, "#{marker.seconds.to_i.to_s}.webp")
@@ -31,9 +33,11 @@ module StashMetadata
             if !File.exist?(marker_path)
               cmd = "ffmpeg -v quiet -ss #{marker.seconds.to_i} -t 5 -i '#{scene.path}' -c:v libwebp -lossless 1 -q:v 70 -compression_level 6 -preset default -loop 0 -threads 4 -vf scale=#{output_width}:-2,fps=12 -an '#{tmp_marker_path}'"
               StashMetadata.logger.info("Create marker for #{marker_path}")
-              system(cmd)
-              FileUtils.cp(tmp_marker_path, marker_path)
-              File.delete(tmp_marker_path)
+              unless system(cmd)
+                StashMetadata.logger.error("Error running ffmpeg #{$?}")
+              end
+
+              FileUtils.mv(tmp_marker_path, marker_path)
             end
           }
         }


### PR DESCRIPTION
- Adds an entry to README.md about the task.
- Improves error handling/reporting when `ffmpeg` fails
- Adds `-strict -2` to `ffmpeg` arguments to fix error about the AAC encoder being experimental
- Changes `cp` & `delete` to `mv` to speed up promoting the temporary file to final location 