### PR TITLE
Set CORS headers for objects served by nginx via X-Accel

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -16,6 +16,12 @@ server {
   location /__send_file_accel {
     internal;
     alias /;
+
+    if ($http_origin) {
+      add_header 'Access-Control-Allow-Origin' "$http_origin";
+      add_header 'Access-Control-Allow-Methods' 'GET';
+      add_header 'Access-Control-Allow-Headers' 'Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+    }
   }
 
   passenger_set_header X-Sendfile-Type "X-Accel-Redirect";


### PR DESCRIPTION
Without this any file served via `send_file` lacks the CORS response headers because it is handled by nginx directly and not Rack (and therefore the rack-cors gem doesn't do its magic)