### PR TITLE
Add metadata:cleanup task

### DIFF
--- a/lib/stash_metadata/tasks/cleanup.rb
+++ b/lib/stash_metadata/tasks/cleanup.rb
@@ -1,0 +1,27 @@
+module StashMetadata
+  module Tasks
+    module Cleanup
+
+      def self.start
+        self.clean_directory(STASH_SCREENSHOTS_DIRECTORY)
+        self.clean_directory(STASH_VTT_DIRECTORY)
+        self.clean_directory(STASH_TRANSCODE_DIRECTORY)
+      end
+
+
+      def self.clean_directory(dir)
+        StashMetadata.logger.info("Cleaning #{dir}")
+
+        Dir.foreach(dir) {|f|
+          if /([a-f0-9]{32})/.match(f)
+            unless Scene.exists?(checksum: $1)
+              StashMetadata.logger.info("Scene for checksum no longer exists: #{$1}")
+              FileUtils.rm_r [File.join(dir, f)]
+            end
+          end
+        }
+      end
+
+    end
+  end
+end

--- a/lib/tasks/metadata.rake
+++ b/lib/tasks/metadata.rake
@@ -35,4 +35,8 @@ namespace :metadata do
     StashMetadata::Tasks::GenerateMarkerPreviews.start
   end
 
+  desc "Cleanup generated files for missing scenes"
+  task cleanup: :environment do
+    StashMetadata::Tasks::Cleanup.start
+  end
 end


### PR DESCRIPTION
Removes files in the metadata directory that are for scenes that have
been removed from the library.