### PR TITLE
Enable redis use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ EXPOSE 80 3000 4000 4001 8008
 
 # Start Nginx / Passenger
 RUN rm -f /etc/service/nginx/down
+RUN rm -f /etc/service/redis/down
 
 # Remove the default site
 RUN rm /etc/nginx/sites-enabled/default

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'puma', '3.11.4'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
+gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 


### PR DESCRIPTION
Action Cable wants to use redis when in production mode.  This allows that by:

- Enabling the redis service in the docker container. 
- Installing redis gem.
