### PR TITLE
Remove semantic build from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,10 +56,6 @@ RUN bundle install
 
 # Install the frontend
 RUN git clone https://github.com/StashApp/StashFrontend.git
-RUN cd StashFrontend/semantic \
-    && npm install gulp \
-    && gulp build \
-    && cd ..
 RUN cd StashFrontend && yarn install
 RUN cd StashFrontend \
     && ng build --prod \


### PR DESCRIPTION
Semantic was removed from StashFrontend in https://github.com/StashApp/StashFrontend/commit/c755bc058fdb8c7da2fe1474e82987d5983e25a9