### PR TITLE
Point FK relationship at correct table

### DIFF
--- a/db/migrate/20180516210129_marker_modifications.rb
+++ b/db/migrate/20180516210129_marker_modifications.rb
@@ -1,7 +1,7 @@
 class MarkerModifications < ActiveRecord::Migration[5.2]
   def change
     change_table :scene_markers do |t|
-      t.references :primary_tag, foreign_key: true
+      t.references :primary_tag, foreign_key: { to_table: :tags }
     end
 
     tag = Tag.create(name: 'PrimaryTagPlaceholder')


### PR DESCRIPTION
On DBs that support FK constraints the migration was attempting to
create a FK pointing to a table named `primary_tags`.  This change
forces the relationship to be against the `tags` table.